### PR TITLE
Add DT overlay for AR0521

### DIFF
--- a/source/ar0521-overlay.dts
+++ b/source/ar0521-overlay.dts
@@ -20,6 +20,7 @@
 
 				clocks = <&cam1_clk>;
 				clock-names = "extclk";
+                    		reset-gpios = <&expgpio 5 GPIO_ACTIVE_LOW>;
 
 				avdd-supply = <&cam1_reg>;
 				dovdd-supply = <&cam_dummy_reg>;

--- a/source/ar0521-overlay.dts
+++ b/source/ar0521-overlay.dts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Definitions for ar0521 camera module on VC I2C bus
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "brcm,bcm2835";
+
+	i2c_frag: fragment@0 {
+		target = <&i2c_csi_dsi>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			ar0521: ar0521@36 {
+				compatible = "onnn,ar0521";
+				reg = <0x36>;
+				status = "okay";
+
+				clocks = <&cam1_clk>;
+				clock-names = "extclk";
+
+				avdd-supply = <&cam1_reg>;
+				dovdd-supply = <&cam_dummy_reg>;
+				dvdd-supply = <&cam_dummy_reg>;
+
+				rotation = <0>;
+				orientation = <2>;
+
+				port {
+					ar0521_0: endpoint {
+						remote-endpoint = <&csi1_ep>;
+						clock-lanes = <0>;
+						data-lanes = <1 2>;
+						clock-noncontinuous;
+						link-frequencies =
+							/bits/ 64 <297000000>;
+					};
+				};
+			};
+		};
+	};
+
+	csi_frag: fragment@1 {
+		target = <&csi1>;
+		csi: __overlay__ {
+			status = "okay";
+
+			port {
+				csi1_ep: endpoint {
+					remote-endpoint = <&ar0521_0>;
+					data-lanes = <1 2>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c0if>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c0mux>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	reg_frag: fragment@4 {
+		target = <&cam1_reg>;
+		__overlay__ {
+			startup-delay-us = <20000>;
+		};
+	};
+
+	clk_frag: fragment@5 {
+		target = <&cam1_clk>;
+		__overlay__ {
+			status = "okay";
+			clock-frequency = <25000000>;
+		};
+	};
+
+	__overrides__ {
+		rotation = <&ar0521>,"rotation:0";
+		orientation = <&ar0521>,"orientation:0";
+		cam0 = <&i2c_frag>, "target:0=",<&i2c_vc>,
+		       <&csi_frag>, "target:0=",<&csi0>,
+		       <&reg_frag>, "target:0=",<&cam0_reg>,
+		       <&clk_frag>, "target:0=",<&cam0_clk>,
+		       <&ar0521>, "clocks:0=",<&cam0_clk>,
+		       <&ar0521>, "avdd-supply:0=",<&cam0_reg>;
+	};
+};


### PR DESCRIPTION
Add initial DT overlay node for AR0521.

FIXME: Add reset gpio.

Signed-off-by: Tejas Patel <tejaspatel.12@outlook.com>