### PR TITLE
ar0521-dts: Disable media-control

### DIFF
--- a/source/ar0521-overlay.dts
+++ b/source/ar0521-overlay.dts
@@ -46,7 +46,6 @@
 		target = <&csi1>;
 		csi: __overlay__ {
 			status = "okay";
-			brcm,media-controller;
 			brcm,num-data-lanes = <0x02>;
 
 			port {
@@ -90,7 +89,6 @@
 	__overrides__ {
 		rotation = <&ar0521>,"rotation:0";
 		orientation = <&ar0521>,"orientation:0";
-		media-controller = <&csi>,"brcm,media-controller?";
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_vc>,
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&reg_frag>, "target:0=",<&cam0_reg>,


### PR DESCRIPTION
media-control was enabled to make driver compatible with libcamera, but we are seeing some issue with
gstreamer v4l2src when media-control is enabled.

Since, libcamera is not in use right now, disable media control untill gstreamer v4l2src is compatible with media-control or when there is plan to move on libcamera or gstreamer with libcamsrc.