### PR TITLE
ar0521: Remove custom controls and update driver for kernel 6.1

### DIFF
--- a/source/ar0521.c
+++ b/source/ar0521.c
@@ -89,26 +89,6 @@
 
 #define AR0521_REG_READ_MODE	0x3040
 
-#define AR0521_REG_ANA_GAIN_CODE_GREENR		0x0206
-#define AR0521_REG_ANA_GAIN_CODE_RED		0x0208
-#define AR0521_REG_ANA_GAIN_CODE_BLUE		0x020A
-#define AR0521_REG_ANA_GAIN_CODE_GREENB		0x020C
-
-#define AR0521_REG_DIGITAL_GAIN_GREENR	0x3032
-#define AR0521_REG_DIGITAL_GAIN_RED	0x3034
-#define AR0521_REG_DIGITAL_GAIN_BLUE	0x3036
-#define AR0521_REG_DIGITAL_GAIN_GREENB	0x3038
-
-/* AR0521 custom control IDs */
-#define V4L2_CID_ANALOGUE_GAIN_GREENR	(V4L2_CID_BASE + 0x1000)
-#define V4L2_CID_ANALOGUE_GAIN_RED	(V4L2_CID_BASE + 0x1001)
-#define V4L2_CID_ANALOGUE_GAIN_BLUE	(V4L2_CID_BASE + 0x1002)
-#define V4L2_CID_ANALOGUE_GAIN_GREENB	(V4L2_CID_BASE + 0x1003)
-#define V4L2_CID_DIGITAL_GAIN_GREENR	(V4L2_CID_BASE + 0x1004)
-#define V4L2_CID_DIGITAL_GAIN_RED	(V4L2_CID_BASE + 0x1005)
-#define V4L2_CID_DIGITAL_GAIN_BLUE	(V4L2_CID_BASE + 0x1006)
-#define V4L2_CID_DIGITAL_GAIN_GREENB	(V4L2_CID_BASE + 0x1007)
-
 #define be		cpu_to_be16
 
 static const char * const ar0521_supply_names[] = {
@@ -787,38 +767,6 @@ static int ar0521_s_ctrl(struct v4l2_ctrl *ctrl)
 				       sensor->ctrls.hflip->val |
 				       sensor->ctrls.vflip->val << 1);
 		break;
-	case V4L2_CID_ANALOGUE_GAIN_GREENR:
-		ret = ar0521_write_reg(sensor, AR0521_REG_ANA_GAIN_CODE_GREENR,
-				       ctrl->val);
-		break;
-	case V4L2_CID_ANALOGUE_GAIN_RED:
-		ret = ar0521_write_reg(sensor, AR0521_REG_ANA_GAIN_CODE_RED,
-				       ctrl->val);
-		break;
-	case V4L2_CID_ANALOGUE_GAIN_BLUE:
-		ret = ar0521_write_reg(sensor, AR0521_REG_ANA_GAIN_CODE_BLUE,
-				       ctrl->val);
-		break;
-	case V4L2_CID_ANALOGUE_GAIN_GREENB:
-		ret = ar0521_write_reg(sensor, AR0521_REG_ANA_GAIN_CODE_GREENB,
-				       ctrl->val);
-		break;
-	case V4L2_CID_DIGITAL_GAIN_GREENR:
-		ret = ar0521_write_reg(sensor, AR0521_REG_DIGITAL_GAIN_GREENR,
-				       min(2047, ctrl->val)); /* Gain = Register Value / 128 */
-		break;
-	case V4L2_CID_DIGITAL_GAIN_RED:
-		ret = ar0521_write_reg(sensor, AR0521_REG_DIGITAL_GAIN_RED,
-				       min(2047, ctrl->val)); /* Gain = Register Value / 128 */
-		break;
-	case V4L2_CID_DIGITAL_GAIN_BLUE:
-		ret = ar0521_write_reg(sensor, AR0521_REG_DIGITAL_GAIN_BLUE,
-				       min(2047, ctrl->val)); /* Gain = Register Value / 128 */
-		break;
-	case V4L2_CID_DIGITAL_GAIN_GREENB:
-		ret = ar0521_write_reg(sensor, AR0521_REG_DIGITAL_GAIN_GREENB,
-				       min(2047, ctrl->val)); /* Gain = Register Value / 128 */
-		break;
 	default:
 		dev_err(&sensor->i2c_client->dev,
 			"Unsupported control %x\n", ctrl->id);
@@ -839,95 +787,6 @@ static const char * const test_pattern_menu[] = {
 	"Solid color",
 	"Color bars",
 	"Faded color bars"
-};
-
-/* -------------------------- custom ctrls ---------------------------------- */
-static const struct v4l2_ctrl_config ar0521_analog_gain_greenr = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_ANALOGUE_GAIN_GREENR,
-	.name = "Analog Gain GreenR",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 32,
-	.step = 1,
-	.def = 4,
-};
-
-static const struct v4l2_ctrl_config ar0521_analog_gain_red = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_ANALOGUE_GAIN_RED,
-	.name = "Analog Gain Red",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 32,
-	.step = 1,
-	.def = 4,
-};
-
-static const struct v4l2_ctrl_config ar0521_analog_gain_blue = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_ANALOGUE_GAIN_BLUE,
-	.name = "Analog Gain Blue",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 32,
-	.step = 1,
-	.def = 4,
-};
-
-static const struct v4l2_ctrl_config ar0521_analog_gain_greenb = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_ANALOGUE_GAIN_GREENB,
-	.name = "Analog Gain GreenB",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 32,
-	.step = 1,
-	.def = 4,
-};
-
-static const struct v4l2_ctrl_config ar0521_digital_gain_greenr = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_DIGITAL_GAIN_GREENR,
-	.name = "Digital Gain GreenR",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 2047,
-	.step = 1,
-	.def = 256,
-};
-
-static const struct v4l2_ctrl_config ar0521_digital_gain_red = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_DIGITAL_GAIN_RED,
-	.name = "Digital Gain Red",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 2047,
-	.step = 1,
-	.def = 384,
-};
-
-static const struct v4l2_ctrl_config ar0521_digital_gain_blue = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_DIGITAL_GAIN_BLUE,
-	.name = "Digital Gain Blue",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 2047,
-	.step = 1,
-	.def = 384,
-};
-
-static const struct v4l2_ctrl_config ar0521_digital_gain_greenb = {
-	.ops = &ar0521_ctrl_ops,
-	.id = V4L2_CID_DIGITAL_GAIN_GREENB,
-	.name = "Digital Gain GreenB",
-	.type = V4L2_CTRL_TYPE_INTEGER,
-	.min = 0,
-	.max = 2047,
-	.step = 1,
-	.def = 256,
 };
 
 static int ar0521_init_controls(struct ar0521_dev *sensor)
@@ -1001,14 +860,6 @@ static int ar0521_init_controls(struct ar0521_dev *sensor)
 					  V4L2_CID_VFLIP, 0, 1, 1, 0);
 	if (ctrls->vflip)
 		ctrls->vflip->flags |= V4L2_CTRL_FLAG_MODIFY_LAYOUT;
-	v4l2_ctrl_new_custom(hdl, &ar0521_analog_gain_greenr, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_analog_gain_red, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_analog_gain_blue, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_analog_gain_greenb, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_digital_gain_greenr, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_digital_gain_red, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_digital_gain_blue, NULL);
-	v4l2_ctrl_new_custom(hdl, &ar0521_digital_gain_greenb, NULL);
 	if (hdl->error) {
 		ret = hdl->error;
 		goto free_ctrls;

--- a/source/ar0521.c
+++ b/source/ar0521.c
@@ -1386,7 +1386,11 @@ entity_cleanup:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,0,0)
 static int ar0521_remove(struct i2c_client *client)
+#else
+static void ar0521_remove(struct i2c_client *client)
+#endif
 {
 	struct v4l2_subdev *sd = i2c_get_clientdata(client);
 	struct ar0521_dev *sensor = to_ar0521_dev(sd);
@@ -1400,7 +1404,9 @@ static int ar0521_remove(struct i2c_client *client)
 	pm_runtime_set_suspended(&client->dev);
 	mutex_destroy(&sensor->lock);
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(6,0,0)
 	return 0;
+#endif
 }
 
 static const struct dev_pm_ops ar0521_pm_ops = {


### PR DESCRIPTION
This patch series contains two major changes.
Update driver for kernel version 6.1
and remove controls which are commented and not in use.

Custom controls were added for color specific analog and digital gains. However, after testing found that global digital and global analog gain, which was already present in driver,  are co-related from hardware.

So, both register set should not be controled from driver.

Register set used by global analong and digital gain Global Analog gain
0x3028

Global Digital Gain
0x3056
0x3058
0x305A
0x305C

Register set used by color specific gain
Analog gains
0x0206
0x0208
0x020A
0x020C

Digital gains
0x3032
0x3034
0x3036
0x3038

Updating anyof global gain affects color specific gain registers and if color specific gain is changed, global gain registers are getting affected, which is hardware behaviour.